### PR TITLE
Remove the `onClickCapture` in the section tag

### DIFF
--- a/src/js/gutenberg/sidebar/toolbar-menu.tsx
+++ b/src/js/gutenberg/sidebar/toolbar-menu.tsx
@@ -56,9 +56,9 @@ export default function ToolbarMenu() {
     return (
         <Dropdown
             contentClassName={styles.dropdown}
-            renderContent={({ onClose }) => (
+            renderContent={() => (
                 <NavigableMenu className={styles.menu}>
-                    <section role="list" onClickCapture={onClose}>
+                    <section role="list">
                         <MenuItem icon="trash" onClick={removeAllCitations}>
                             {__(
                                 'Remove all citations',


### PR DESCRIPTION
Removing the onClickCapture in the section tag allows the dialog to now populate properly. 

<img width="1284" alt="Screen Shot 2022-02-16 at 11 38 01 PM" src="https://user-images.githubusercontent.com/2303074/154406927-5d2f0039-cf15-4fae-a046-1da25b3e188c.png">

While I'm not certain exactly what this does, I was able to figure out that it has to do with click handler bubbling. None of which was required within any subcomponent, so I removed it.

